### PR TITLE
Improve error message, with an arrow pointing to the 'failing' marble.

### DIFF
--- a/src/Divverence.MarbleTesting.Akka/Properties/AssemblyInfo.cs
+++ b/src/Divverence.MarbleTesting.Akka/Properties/AssemblyInfo.cs
@@ -1,4 +1,7 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
 [assembly: AssemblyTitle("Divverence.MarbleTesting.Akka")]
 [assembly: AssemblyDescription("Divverence.MarbleTesting Library for Akka.Net")]
+[assembly: InternalsVisibleTo("Divverence.MarbelTesting.Tests")]
 

--- a/src/Divverence.MarbleTesting.v3.ncrunchsolution
+++ b/src/Divverence.MarbleTesting.v3.ncrunchsolution
@@ -1,0 +1,6 @@
+﻿<SolutionConfiguration>
+  <Settings>
+    <AllowParallelTestExecution>True</AllowParallelTestExecution>
+    <SolutionConfigured>True</SolutionConfigured>
+  </Settings>
+</SolutionConfiguration>

--- a/src/Divverence.MarbleTesting/Divverence.MarbleTesting.csproj
+++ b/src/Divverence.MarbleTesting/Divverence.MarbleTesting.csproj
@@ -43,6 +43,11 @@
     <Compile Include="..\..\built\SharedAssemblyInfo*.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="ErrorMessageHelper.cs" />
+    <Compile Include="ExpectedMarble.cs" />
+    <Compile Include="ExpectedMarbles.cs" />
+    <Compile Include="InputMarble.cs" />
+    <Compile Include="InputMarbles.cs" />
     <Compile Include="MarbleParser.cs" />
     <Compile Include="MarbleTest.cs" />
     <Compile Include="Moment.cs" />

--- a/src/Divverence.MarbleTesting/ErrorMessageHelper.cs
+++ b/src/Divverence.MarbleTesting/ErrorMessageHelper.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Divverence.MarbleTesting
+{
+    internal static class ErrorMessageHelper
+    {
+        internal const string UpArrow = "\u2191";
+
+        internal static string SequenceWithPointerToOffendingMoment(string sequence, int offensiveMoment)
+        {
+            return $"{Environment.NewLine}  {sequence}{Environment.NewLine}  {UpArrow.PadLeft(offensiveMoment + 1)}";
+        }
+    }
+}

--- a/src/Divverence.MarbleTesting/ExpectedMarble.cs
+++ b/src/Divverence.MarbleTesting/ExpectedMarble.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Divverence.MarbleTesting
+{
+    public class ExpectedMarble
+    {
+        public ExpectedMarble(int time, string marble, Action assertion)
+        {
+            Time = time;
+            Marble = marble;
+            Assertion = assertion;
+        }
+
+        public int Time { get; }
+        public string Marble { get; }
+        public Action Assertion { get; }
+    }
+}

--- a/src/Divverence.MarbleTesting/ExpectedMarbles.cs
+++ b/src/Divverence.MarbleTesting/ExpectedMarbles.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Divverence.MarbleTesting
+{
+    public class ExpectedMarbles
+    {
+        public ExpectedMarbles(string sequence, IEnumerable<ExpectedMarble> expectations)
+        {
+            Sequence = sequence;
+            Expectations = expectations.ToImmutableList();
+            FirstTime = Expectations.Min(e => e.Time);
+            LastTime = Expectations.Max(e => e.Time);
+        }
+
+        public string Sequence { get; }
+        public ImmutableList<ExpectedMarble> Expectations { get; }
+        public int LastTime { get; set; }
+        public int FirstTime { get; set; }
+
+        public bool Verify(int time)
+        {
+            var expectations = Expectations.Where(e => e.Time == time).ToList();
+            if (!expectations.Any())
+                return false;
+
+            foreach (var exp in expectations)
+                try
+                {
+                    exp.Assertion();
+                }
+                catch (Exception e)
+                {
+                    if (exp.Marble == null)
+                        throw new Exception(
+                            $"Unexpected event received at time {time} on sequence {ErrorMessageHelper.SequenceWithPointerToOffendingMoment(Sequence, time)}", e);
+                    throw new Exception(
+                        $"Marble '{exp.Marble}' not received at time {time} on sequence {ErrorMessageHelper.SequenceWithPointerToOffendingMoment(Sequence, time)}", e);
+                }
+            return true;
+        }
+    }
+}

--- a/src/Divverence.MarbleTesting/InputMarble.cs
+++ b/src/Divverence.MarbleTesting/InputMarble.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Divverence.MarbleTesting
+{
+    public class InputMarble
+    {
+        public InputMarble(int time, string marble, Func<Task> action)
+        {
+            Time = time;
+            Marble = marble;
+            Action = action;
+        }
+
+        public int Time { get; }
+        public string Marble { get; }
+        public Func<Task> Action { get; }
+    }
+}

--- a/src/Divverence.MarbleTesting/InputMarbles.cs
+++ b/src/Divverence.MarbleTesting/InputMarbles.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Divverence.MarbleTesting
+{
+    public class InputMarbles
+    {
+        public InputMarbles(string sequence, IEnumerable<InputMarble> actions)
+        {
+            Sequence = sequence;
+            Actions = actions.ToImmutableList();
+        }
+
+        public string Sequence { get; }
+        public ImmutableList<InputMarble> Actions { get; }
+
+        public Task Run(int time)
+        {
+            return Task.WhenAll(Actions.Where(e => e.Time == time).Select(exp => Run(exp, time)));
+        }
+
+        private async Task Run(InputMarble m, int time)
+        {
+            try
+            {
+                await m.Action();
+            }
+            catch (Exception e)
+            {
+                throw new Exception(
+                    $"Error when firing marble '{m.Marble}' at time {time} on sequence {ErrorMessageHelper.SequenceWithPointerToOffendingMoment(Sequence, time)}", e);
+            }
+        }
+    }
+}

--- a/src/Divverence.MarbleTesting/MarbleTest.cs
+++ b/src/Divverence.MarbleTesting/MarbleTest.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -59,102 +58,6 @@ namespace Divverence.MarbleTesting
         protected IEnumerable<InputMarble> CreateInputMarbles(Moment moment, Func<string, Task> whatToDo)
         {
             return moment.Marbles.Select(marble => new InputMarble(moment.Time, marble, () => whatToDo(marble)));
-        }
-
-        protected class ExpectedMarble
-        {
-            public ExpectedMarble(int time, string marble, Action assertion)
-            {
-                Time = time;
-                Marble = marble;
-                Assertion = assertion;
-            }
-
-            public int Time { get; }
-            public string Marble { get; }
-            public Action Assertion { get; }
-        }
-
-        protected class ExpectedMarbles
-        {
-            public ExpectedMarbles(string sequence, IEnumerable<ExpectedMarble> expectations)
-            {
-                Sequence = sequence;
-                Expectations = expectations.ToImmutableList();
-                FirstTime = Expectations.Min(e => e.Time);
-                LastTime = Expectations.Max(e => e.Time);
-            }
-
-            public string Sequence { get; }
-            public ImmutableList<ExpectedMarble> Expectations { get; }
-            public int LastTime { get; set; }
-            public int FirstTime { get; set; }
-
-            public bool Verify(int time)
-            {
-                var expectations = Expectations.Where(e => e.Time == time).ToList();
-                if (!expectations.Any())
-                    return false;
-
-                foreach (var exp in expectations)
-                    try
-                    {
-                        exp.Assertion();
-                    }
-                    catch (Exception e)
-                    {
-                        if (exp.Marble == null)
-                            throw new Exception(
-                                $"Unexpected event received at time {time} on sequence {Sequence}", e);
-                        throw new Exception(
-                            $"Marble '{exp.Marble}' not received at time {time} on sequence {Sequence}", e);
-                    }
-                return true;
-            }
-        }
-
-        protected class InputMarble
-        {
-            public InputMarble(int time, string marble, Func<Task> action)
-            {
-                Time = time;
-                Marble = marble;
-                Action = action;
-            }
-
-            public int Time { get; }
-            public string Marble { get; }
-            public Func<Task> Action { get; }
-        }
-
-        protected class InputMarbles
-        {
-            public InputMarbles(string sequence, IEnumerable<InputMarble> actions)
-            {
-                Sequence = sequence;
-                Actions = actions.ToImmutableList();
-            }
-
-            public string Sequence { get; }
-            public ImmutableList<InputMarble> Actions { get; }
-
-            public Task Run(int time)
-            {
-                return Task.WhenAll(Actions.Where(e => e.Time == time).Select(exp => Run(exp, time)));
-            }
-
-            private async Task Run(InputMarble m, int time)
-            {
-                try
-                {
-                    await m.Action();
-                }
-                catch (Exception e)
-                {
-                    throw new Exception(
-                        $"Error when firing marble '{m.Marble}' at time {time} on sequence {Sequence}", e);
-                }
-            }
         }
     }
 }

--- a/src/Divverence.MarbleTesting/Properties/AssemblyInfo.cs
+++ b/src/Divverence.MarbleTesting/Properties/AssemblyInfo.cs
@@ -1,4 +1,6 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
 [assembly: AssemblyTitle("Divverence.MarbleTesting")]
 [assembly: AssemblyDescription("Divverence.MarbleTesting Core Library")]
-
+[assembly: InternalsVisibleTo("Divverence.MarbleTesting.Tests")]

--- a/tst/Divverence.MarbleTesting.Tests/Divverence.MarbleTesting.Tests.csproj
+++ b/tst/Divverence.MarbleTesting.Tests/Divverence.MarbleTesting.Tests.csproj
@@ -42,6 +42,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MarbleParserTest.cs" />
+    <Compile Include="ErrorMessageHelperTest.cs" />
     <Compile Include="MultiCharMarbleParserTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/tst/Divverence.MarbleTesting.Tests/ErrorMessageHelperTest.cs
+++ b/tst/Divverence.MarbleTesting.Tests/ErrorMessageHelperTest.cs
@@ -1,0 +1,26 @@
+﻿using Xunit;
+
+namespace Divverence.MarbleTesting.Tests
+{
+    public class ErrorMessageHelperTest
+    {
+        [Theory]
+        [InlineData("-x-", 0, 
+            @"
+  -x-
+  ↑")]
+        [InlineData("-x-", 1, 
+            @"
+  -x-
+   ↑")]
+        [InlineData("-x-", 2, 
+            @"
+  -x-
+    ↑")]
+        public void ShouldProvidePointerToOffendingMarbleAtCorrectPoint(string sequence, int offender, string expected)
+        {
+            var actual = ErrorMessageHelper.SequenceWithPointerToOffendingMoment(sequence, offender);
+            Assert.Equal(expected, actual);
+        }
+    }
+}


### PR DESCRIPTION
- Extract marble classes into seperate files.